### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions-minor-patch:
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Adds a `.github/dependabot.yml` enabling weekly Dependabot version updates.
Minor and patch bumps are grouped per ecosystem; major bumps and security
updates stay as separate PRs. Auto-generated by rollout.sh.