### PR TITLE
Add reusable Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: Dependabot auto-merge
+
+# Reusable workflow. Enables auto-merge on Dependabot PRs for low-risk update
+# types. Call it from a repo's own `on: pull_request` workflow (see
+# repo.dependabot-auto-merge.yml).
+#
+# Auto-merge only *completes* once the target branch's required status checks
+# pass, so this relies on a branch ruleset (require a PR + required checks) on
+# the consuming repo. Without that ruleset, `gh pr merge --auto` has nothing to
+# wait for. Major bumps and anything outside allowed-update-types are left for
+# manual review.
+
+on:
+  workflow_call:
+    inputs:
+      merge-method:
+        description: "Merge method: merge | squash | rebase"
+        type: string
+        default: "squash"
+      allowed-update-types:
+        description: "Comma-separated Dependabot update-types to auto-merge"
+        type: string
+        default: "version-update:semver-patch,version-update:semver-minor"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for allowed update types
+        if: contains(inputs.allowed-update-types, steps.meta.outputs.update-type)
+        run: gh pr merge --auto --${{ inputs.merge-method }} "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a reusable workflow `.github/workflows/dependabot-auto-merge.yml` — the foundational piece of the Dependabot auto-merge rollout (see Monday board "Dependency Remediation — June 2026", group "AUTO").

## What it does
Called from a repo's own `on: pull_request` workflow, it:
- runs only for `dependabot[bot]` PRs,
- reads the update-type via `dependabot/fetch-metadata`,
- enables native auto-merge (`gh pr merge --auto --squash`) **only** for `semver-patch` / `semver-minor` (configurable via `allowed-update-types`).

Majors and security PRs are left for manual review.

## How it stays safe
Auto-merge only *completes* once the target branch's **required status checks** pass. That gate comes from a separate org ruleset (require PR + required `ci` check on `main`, with the Core team on the bypass list so humans keep pushing to main directly). Without that ruleset there is nothing for `--auto` to wait on, so this workflow is a no-op until the ruleset + per-repo CI land.

## Consuming it
Each repo adds a small caller pinned to a released tag, e.g.:
```yaml
jobs:
  auto-merge:
    if: github.actor == 'dependabot[bot]'
    uses: WeMoveEU/ci-workflows/.github/workflows/dependabot-auto-merge.yml@v13
```
(The caller must grant `contents: write` + `pull-requests: write` — a reusable workflow's effective token is capped by the caller's.)

## Follow-up
Cut a new `vN` tag after merge so consumers can pin it.