### PR TITLE
Pilot: actionlint CI gate + Dependabot auto-merge caller

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+# Per-repo caller. Drop into .github/workflows/ of each consuming repo.
+# It runs on every PR but the reusable only acts on Dependabot PRs.
+#
+# The permissions block here MUST grant contents+pull-requests write: a called
+# workflow's effective GITHUB_TOKEN permissions are capped by the caller's.
+# GITHUB_TOKEN is passed to the reusable automatically (no `secrets: inherit`).
+#
+# Pin the reusable to a released tag of ci-workflows. v13 is the first tag that
+# contains it. Dependabot's github-actions ecosystem will open PRs bumping this
+# ref as new tags are cut — which the auto-merge this enables will then land.
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    uses: WeMoveEU/ci-workflows/.github/workflows/dependabot-auto-merge.yml@v13
+    # Override defaults if desired, e.g. patch-only for runtime-heavy repos:
+    # with:
+    #   allowed-update-types: "version-update:semver-patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+# PR gate for ci-workflows. The repo only holds reusable (workflow_call)
+# workflows, which can't meaningfully self-run on a PR, so the gate is
+# actionlint over the workflow files. The job is named `ci` so it produces a
+# status check named "ci" — the exact context the org ruleset requires.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: actionlint
+        uses: raven-actions/actionlint@v2


### PR DESCRIPTION
First end-to-end pilot of the Dependabot auto-merge rollout (Monday board "Dependency Remediation — June 2026", group "AUTO"). ci-workflows is the lowest-risk repo — its only Dependabot updates are github-actions version bumps.

## Adds
- **`.github/workflows/ci.yml`** — PR gate. ci-workflows holds only reusable (`workflow_call`) workflows that can't self-run on a PR, so the gate is **actionlint** over the workflow files. The job is named `ci`, producing a status check named **`ci`** — the exact context the org ruleset will require.
- **`.github/workflows/automerge.yml`** — caller for the reusable added in #6, pinned to `@v13`. (Named `automerge.yml`, not `dependabot-auto-merge.yml`, because this repo already hosts the reusable at that path.) Runs only on `dependabot[bot]` PRs and enables native auto-merge for `semver-patch`/`semver-minor`.

## Still required for auto-merge to actually fire (separate, after merge)
1. Enable **Allow auto-merge** on this repo's settings.
2. Apply the org ruleset **scoped to ci-workflows only** (require PR + `ci` check on `main`, Core team bypass). The ruleset is what gives `gh pr merge --auto` something to wait on.

Once those two are in place, the next github-actions Dependabot PR here should merge itself after `ci` goes green.