### PR TITLE
Adopt semver + floating-major tagging (RELEASING.md)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    uses: WeMoveEU/ci-workflows/.github/workflows/dependabot-auto-merge.yml@v13
+    uses: WeMoveEU/ci-workflows/.github/workflows/dependabot-auto-merge.yml@v14
     # Override defaults if desired, e.g. patch-only for runtime-heavy repos:
     # with:
     #   allowed-update-types: "version-update:semver-patch"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,53 @@
+# Releasing ci-workflows
+
+This repo publishes reusable workflows (`.github/workflows/*.yml`) and composite
+actions (`.github/actions/*`) that other WeMove repos call. We version them with
+**semver tags plus a floating major tag**, so consumers pin a major and pick up
+minor/patch fixes automatically.
+
+## Tagging scheme
+
+For every release, create an **immutable** version tag and move the **floating
+major** tag to it:
+
+- `vMAJOR.MINOR.PATCH` — immutable, never moved (e.g. `v14.0.0`).
+- `vMAJOR` — floating, always points at the latest `vMAJOR.*` release (e.g. `v14`).
+
+Bump rules:
+
+- **Patch / minor** (backward-compatible fix or additive input): cut
+  `vMAJOR.(MINOR|PATCH+1)` and move `vMAJOR` to it. Consumers on `@vMAJOR` get
+  it with no PR.
+- **Major** (breaking change to inputs/behavior): cut `v(MAJOR+1).0.0` and
+  create a new floating `v(MAJOR+1)`. Consumers stay on the old major until they
+  opt in; Dependabot opens the major-bump PR for them.
+
+## How consumers pin
+
+Always pin the **floating major**:
+
+```yaml
+uses: WeMoveEU/ci-workflows/.github/workflows/docker-build.yml@v14
+uses: WeMoveEU/ci-workflows/.github/actions/docker-smoke@v14
+```
+
+Dependabot (github-actions ecosystem) leaves `@v14` alone and only opens a PR
+when a new major (`v15`) appears — so minor/patch fixes flow in automatically
+and only breaking changes require review.
+
+## Cutting a release
+
+```bash
+SHA=$(gh api repos/WeMoveEU/ci-workflows/git/ref/heads/main --jq '.object.sha')
+# immutable
+gh api repos/WeMoveEU/ci-workflows/git/refs -f ref="refs/tags/v14.1.0" -f sha="$SHA"
+# move the floating major
+gh api -X PATCH repos/WeMoveEU/ci-workflows/git/refs/tags/v14 -F sha="$SHA" -F force=true
+```
+
+## History
+
+Tags `v1`–`v13` predate this scheme — they are frozen point releases, not
+floating majors. The floating-major convention starts at **`v14`** (the first
+release that also ships the `docker-smoke` action). Repos still pinned to older
+integer tags keep working; migrate them to `@v14` as they're touched.


### PR DESCRIPTION
## What
- Adds **RELEASING.md** documenting the versioning convention: immutable `vMAJOR.MINOR.PATCH` tags + a floating `vMAJOR` tag that consumers pin. Minor/patch fixes flow in automatically; only a new major needs a Dependabot bump/review.
- Pins this repo's own auto-merge caller (`automerge.yml`) to floating `@v14`.

## Context
`v14.0.0` was tagged and the floating `v14` now points at it (docker-smoke + build-only + the auto-merge reusable). Tags `v1`–`v13` are frozen legacy point releases; the floating-major convention starts at `v14`. Active repos (toolbox, bankimporter, ecm) are being repointed to `@v14`; the ~16 other consumers on older integer tags keep working and migrate as touched.